### PR TITLE
Prevent panic when send to worker channel

### DIFF
--- a/types.go
+++ b/types.go
@@ -74,6 +74,7 @@ type Listener interface {
 
 	// GetListener returns listener by name
 	GetListener(string) Listener
+	CacheBlocks(blockNumbers map[uint64]struct{})
 }
 
 type Transaction interface {

--- a/worker.go
+++ b/worker.go
@@ -41,7 +41,7 @@ func (w *BridgeWorker) String() string {
 func (w *BridgeWorker) ProcessJob(job JobHandler) error {
 	val, err := job.Process()
 	if err != nil {
-		log.Error("[BridgeWorker] failed while processing job", "id", job.GetID(), "err", err, "stack", stack.Trace().String())
+		log.Error("[BridgeWorker] failed while processing job", "retry", job.GetRetryCount(), "err", err, "stack", stack.Trace().String())
 		return err
 	}
 	if job.GetType() == ListenHandler && job.GetSubscriptionName() != "" {


### PR DESCRIPTION
- wrapup send job to worker channel into a function to prevent panic "send to closed channel"
- cache block and transactions during getting logs data
- stop loading pending job from database when context is closed